### PR TITLE
ISSUE-335: locked solidity pragma to v0.5.11

### DIFF
--- a/src/LineSpell.sol
+++ b/src/LineSpell.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 contract PauseLike {
     function delay() public view returns (uint256);

--- a/src/LineSpell.t.sol
+++ b/src/LineSpell.t.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 import "ds-test/test.sol";
 import "dss-deploy/DssDeploy.t.base.sol";

--- a/src/MultiLineSpell.sol
+++ b/src/MultiLineSpell.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 contract PauseLike {
     function delay() public view returns (uint256);

--- a/src/MultiLineSpell.t.sol
+++ b/src/MultiLineSpell.t.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 import "ds-test/test.sol";
 import "dss-deploy/DssDeploy.t.base.sol";


### PR DESCRIPTION
```
Running 3 tests for src/LineSpell.t.sol:LineSpellTest
[PASS] testCast() (gas: 1910675)
[PASS] testConstructor() (gas: 1509226)
[PASS] testFailRepeatedCast() (gas: 1907992)

Running 7 tests for src/MultiLineSpell.t.sol:MultiLineSpellTest
[PASS] testCast() (gas: 2507139)
[PASS] testConstructor() (gas: 1723548)
[PASS] testFailCastBothEmpty() (gas: 37558)
[PASS] testFailCastEmptyIlks() (gas: 78602)
[PASS] testFailCastEmptyLines() (gas: 78586)
[PASS] testFailCastMismatchedLengths() (gas: 95319)
[PASS] testFailRepeatedCast() (gas: 2496740)
```