### PR TITLE
Pragma update

### DIFF
--- a/src/LineSpell.sol
+++ b/src/LineSpell.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 contract PauseLike {
     function delay() public view returns (uint256);

--- a/src/LineSpell.t.sol
+++ b/src/LineSpell.t.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 import "ds-test/test.sol";
 import "dss-deploy/DssDeploy.t.base.sol";

--- a/src/MultiLineSpell.sol
+++ b/src/MultiLineSpell.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 contract PauseLike {
     function delay() public view returns (uint256);

--- a/src/MultiLineSpell.t.sol
+++ b/src/MultiLineSpell.t.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity ^0.5.4;
+pragma solidity 0.5.11;
 
 import "ds-test/test.sol";
 import "dss-deploy/DssDeploy.t.base.sol";


### PR DESCRIPTION
This commit updated the solidity pragma to `v0.5.11` and pulls in some `dss-deploy` dependency updates usually pulled in by @gbalabasquer scripts.